### PR TITLE
uses parameter name , not static text 'docker-service'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ ONBUILD RUN  source /tmp/docker.properties \
       && chown -R $service_name:$service_name /opt/$service_name  \
       && ls -al  /opt/${service_name}    \
       && ls -al  /var/log/${service_name} \
-      && cat /etc/service/docker-service/run    \
+      && cat /etc/service/${service_name}/run    \
       && rm -rf /tmp/
 
 

--- a/docker-service-startup-command.sh
+++ b/docker-service-startup-command.sh
@@ -2,6 +2,6 @@
 
 if [ "$SERVICE_CMD" != "server" ]
 then
- 	sh /etc/service/docker-service/run
+ 	sh /etc/service/${service_name}/run
 fi
 echo server > /etc/container_environment/SERVICE_CMD


### PR DESCRIPTION
parameter service-name