### PR TITLE
LOF-22 Create alpine-based micros base image for new Experience env

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,64 @@
+FROM openjdk:8-jre-alpine
+
+MAINTAINER Matteo Remo Luzzi <matteo@vimond.com>
+
+RUN apk add --no-cache bash
+
+#Install new relic agent
+ADD https://download.newrelic.com/newrelic/java-agent/newrelic-agent/3.22.1/newrelic-java.zip /tmp/newrelic-java.zip
+COPY newrelic.yml /tmp/newrelic.yml
+COPY newrelic-extensions/* /tmp/newrelic-extensions/
+
+#Copy build files
+COPY docker-service-alpine.sh /tmp/docker-service.sh
+COPY build-alpine.sh /tmp/build.sh
+RUN chmod a+x /tmp/build.sh
+
+ONBUILD COPY docker/docker-config.yml docker/docker.properties build/libs/*.jar target/*.jar /tmp/
+ONBUILD RUN rm -fv /tmp/*tests*.jar
+
+ONBUILD RUN /tmp/build.sh
+
+# Set this to a valid new relic license key to activate the new relic agent
+ENV NEW_RELIC_LICENSE_KEY ""
+
+
+ENV JAVA_OPTIONS -server \
+-d64 \
+-Djava.net.preferIPv4Stack=true \
+-XX:+UseNUMA \
+-XX:+UseCompressedOops \
+-XX:+UseG1GC \
+-XX:+AggressiveOpts \
+-XX:+UseFastAccessorMethods \
+-XX:+UseBiasedLocking \
+-XX:NewRatio=2 \
+-XX:+HeapDumpOnOutOfMemoryError \
+-XX:HeapDumpPath=/opt/gatekeeper \
+-XX:+PrintGC \
+-XX:+PrintGCDetails \
+-XX:+PrintGCTimeStamps \
+-XX:GCLogFileSize=20M \
+-XX:NumberOfGCLogFiles=15 \
+-XX:+UseGCLogFileRotation \
+-XX:+PrintGCDateStamps \
+-XX:+PrintPromotionFailure \
+-Djava.security.egd=file:/dev/urandom \
+-Dcom.sun.management.jmxremote \
+-Dcom.sun.management.jmxremote.port=9010 \
+-Dcom.sun.management.jmxremote.rmi.port=9010 \
+-Dcom.sun.management.jmxremote.local.only=false \
+-Dcom.sun.management.jmxremote.authenticate=false \
+-Dcom.sun.management.jmxremote.ssl=false \
+-XX:-ReduceInitialCardMarks
+
+ENV JAVA_MEMORY -Xmx500m
+
+# Makes all docker dw apps log json if using: ${VIMOND_DW_CONSOLE_LOG_FORMAT:-console} as config-entry
+ENV VIMOND_DW_CONSOLE_LOG_FORMAT console-logstash
+
+EXPOSE 9010
+
+CMD ["server"]
+
+ENTRYPOINT ["/usr/bin/docker-service.sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -5,7 +5,7 @@ MAINTAINER Matteo Remo Luzzi <matteo@vimond.com>
 RUN apk add --no-cache bash
 
 #Install new relic agent
-ADD https://download.newrelic.com/newrelic/java-agent/newrelic-agent/3.22.1/newrelic-java.zip /tmp/newrelic-java.zip
+ADD https://download.newrelic.com/newrelic/java-agent/newrelic-agent/3.35.2/newrelic-java.zip /tmp/newrelic-java.zip
 COPY newrelic.yml /tmp/newrelic.yml
 COPY newrelic-extensions/* /tmp/newrelic-extensions/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+DOCKER_PRIVATE_REPO ?= vimond-dockerv2-local.jfrog.io
+NAME = $(DOCKER_PRIVATE_REPO)/micros-baseimage
+VERSION = $(shell git describe --tags --always)
+
+
+.PHONY: all build test tag_latest release
+
+all: build
+
+build:
+	docker build  -t $(NAME):$(VERSION)  .
+	docker build  -t $(NAME):alpine-$(VERSION)   -f Dockerfile.alpine .
+
+test:
+	docker run --rm $(NAME):$(VERSION) java -version
+	docker run --rm $(NAME):alpine-$(VERSION) java -version
+
+tag_latest:
+	docker tag  $(NAME):$(VERSION) $(NAME):latest
+	docker tag  $(NAME):alpine-$(VERSION) $(NAME):alpine-latest
+
+release: test tag_latest
+	@if ! docker images $(NAME) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME) version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	docker push $(NAME)

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ all: build
 
 build:
 	docker build  -t $(NAME):$(VERSION)  .
-	docker build  -t $(NAME):alpine-$(VERSION)   -f Dockerfile.alpine .
+	docker build  -t $(NAME):alpine-$(VERSION)  -f Dockerfile.alpine .
 
 test:
-	docker run --rm $(NAME):$(VERSION) java -version
-	docker run --rm $(NAME):alpine-$(VERSION) java -version
+	docker run --rm --entrypoint java $(NAME):$(VERSION) -version
+	docker run --rm --entrypoint java $(NAME):alpine-$(VERSION) -version
 
 tag_latest:
 	docker tag  $(NAME):$(VERSION) $(NAME):latest

--- a/build-alpine.sh
+++ b/build-alpine.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#Notes on variables below. $UPPER_CASE means variables to be evaluated at runtime.
+#Variables with $lower_case means the var should used only in the Dockerfile image build phase.
+#This is for keeping the confusion at bay.
+source /tmp/docker.properties
+mkdir /opt
+adduser -s /bin/bash -h /opt/$service_name -D $service_name docker_env
+mkdir /var/log/${service_name}
+
+#New relic agent installation
+unzip -d /opt/$service_name/ /tmp/newrelic-java.zip
+cp /tmp/newrelic.yml /opt/$service_name/newrelic/
+mkdir /opt/$service_name/newrelic/extensions/
+cp /tmp/newrelic-extensions/*.xml /opt/$service_name/newrelic/extensions/
+
+#Startup script
+mv /tmp/docker-service.sh /usr/bin/docker-service.sh
+chmod -R a+x /usr/bin/docker-service.sh
+
+#/etc/container_environment variables are exported only in phusion/base-image, not in alpine. Workaround by writing them into /etc/profile and sourcing the file later
+echo "export NEW_RELIC_APP_NAME=$service_name" >> /etc/profile
+echo "export NEW_RELIC_LOG=STDOUT" >> /etc/profile
+echo "export SERVICE_NAME=$service_name" >> /etc/profile
+echo "export SERVICE_CMD=server" >> /etc/profile
+echo "export SERVICE_CONFIG=/opt/$service_name/config.yml" >> /etc/profile
+echo "export JAVA_LOGGC=-Xloggc:/var/log/$service_name/gc.log " >> /etc/profile
+
+#Service files and folders
+mv /tmp/docker-config.yml /opt/$service_name/config.yml
+mv /tmp/*.jar /opt/$service_name
+echo "docker.properties: $(cat /tmp/docker.properties)"
+chown -R $service_name:$service_name /var/log/$service_name
+chown -R $service_name:$service_name /opt/$service_name
+ls -al  /opt/${service_name}
+ls -al  /var/log/${service_name}
+
+# cleanup
+rm -rf /tmp/*

--- a/build-alpine.sh
+++ b/build-alpine.sh
@@ -4,7 +4,7 @@
 #This is for keeping the confusion at bay.
 source /tmp/docker.properties
 mkdir /opt
-adduser -s /bin/bash -h /opt/$service_name -D $service_name docker_env
+adduser -s /bin/bash -h /opt/$service_name -u ${user_id:-1000}  -D $service_name docker_env
 mkdir /var/log/${service_name}
 
 #New relic agent installation

--- a/circle.yml
+++ b/circle.yml
@@ -10,31 +10,13 @@ dependencies:
   override:
     - docker info
     - docker login -u $ARTIFACTORY_USER -p $ARTIFACTORY_PASSWORD -e developers@vimond.com $DOCKER_PRIVATE_REPO
-    - if [[ -e ~/docker/image.tgz ]]; then gunzip -c ~/docker/image.tgz | docker load ; fi
-    - docker build -t $IMAGE_NAME:$CIRCLE_BUILD_NUM .
-
-    - mkdir -p ~/docker; docker save $IMAGE_NAME:$CIRCLE_BUILD_NUM | gzip -c > ~/docker/image.tgz;
-#    - if [[ ! -e ~/docker/image.tgz ]]; then mkdir -p ~/docker; docker save $IMAGE_NAME:$CIRCLE_BUILD_NUM | gzip -c > ~/docker/image.tgz; fi
-
+    - make build
 test:
   override:
-    - docker run  $IMAGE_NAME:$CIRCLE_BUILD_NUM ls
-#    - curl --retry 10 --retry-delay 5 -v http://localhost:80 (or something similar)
+    - make test
 
 deployment:
-#  hub:
-#    branch: master
-#    commands:
-#      - docker login -e developers@vimond.com -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-#      - docker tag -f $IMAGE_NAME:$CIRCLE_BUILD_NUM vimond/$IMAGE_NAME:latest
-#      - docker tag    $IMAGE_NAME:$CIRCLE_BUILD_NUM vimond/$IMAGE_NAME:$CIRCLE_BUILD_NUM
-#      - docker push vimond/$IMAGE_NAME:$CIRCLE_BUILD_NUM
-#      - docker push vimond/$IMAGE_NAME:latest
   docker:
     branch: master
     commands:
-      - docker login -u $ARTIFACTORY_USER -p $ARTIFACTORY_PASSWORD -e developers@vimond.com $DOCKER_PRIVATE_REPO
-      - docker tag -f $IMAGE_NAME:$CIRCLE_BUILD_NUM $DOCKER_PRIVATE_REPO/$IMAGE_NAME:latest
-      - docker tag    $IMAGE_NAME:$CIRCLE_BUILD_NUM $DOCKER_PRIVATE_REPO/$IMAGE_NAME:$CIRCLE_BUILD_NUM
-      - docker push $DOCKER_PRIVATE_REPO/$IMAGE_NAME:$CIRCLE_BUILD_NUM
-      - docker push $DOCKER_PRIVATE_REPO/$IMAGE_NAME:latest
+      - make release

--- a/docker-service-alpine.sh
+++ b/docker-service-alpine.sh
@@ -11,9 +11,10 @@ fi
 java_exec="java $JAVA_OPTIONS $JAVA_NEW_RELIC_OPTIONS $JAVA_PROMETHEUS_AGENT_OPTIONS $JAVA_MEMORY $JAVA_LOGGC $JAVA_RUNTIME_OPTIONS -jar ${service_jar} $@  $SERVICE_CONFIG"
 
 if [ "$(whoami)" == "root" ] ; then
-    su $SERVICE_NAME -c "exec $java_exec"
+    echo "Running the container as a root, it won't propagate SIGTERM signal.\nTo avoid this specify the directive 'USER ${SERVICE_NAME}' into your service Dockerfile"
+    exit 1
 elif [ "$(whoami)" == ${SERVICE_NAME} ]; then
-    $java_exec
+    exec $java_exec
 else
     echo "$(whoami) not authorised to start the service process"
 fi

--- a/docker-service-alpine.sh
+++ b/docker-service-alpine.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+source /etc/profile
+
+service_jar=$(ls -1t /opt/${SERVICE_NAME}/*.jar|head -1)
+
+JAVA_NEW_RELIC_OPTIONS=""
+if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
+    JAVA_NEW_RELIC_OPTIONS="-javaagent:/opt/$SERVICE_NAME/newrelic/newrelic.jar"
+fi
+
+java_exec="java $JAVA_OPTIONS $JAVA_NEW_RELIC_OPTIONS $JAVA_PROMETHEUS_AGENT_OPTIONS $JAVA_MEMORY $JAVA_LOGGC $JAVA_RUNTIME_OPTIONS -jar ${service_jar} $@  $SERVICE_CONFIG"
+
+if [ "$(whoami)" == "root" ] ; then
+    su $SERVICE_NAME -c "exec $java_exec"
+elif [ "$(whoami)" == ${SERVICE_NAME} ]; then
+    $java_exec
+else
+    echo "$(whoami) not authorised to start the service process"
+fi


### PR DESCRIPTION
This pull request aims at creating a new base Docker image based on Alpine linux for all the Vimond microservices. 
The benefits of using Alpine linux as base layer are:
* Lightweight images
* Fail-fast containers
The latter benefit is crucial for settling the foundations of the new Experience VPC based on Kubernetes

The pull request tries to make the transition to this new base images as much transparent as possible. The current dockerfiles of the micros won't require any changes.